### PR TITLE
Add requirements.txt files for js8_get_msgs and js8web modules

### DIFF
--- a/js8_get_msgs/requirements.txt
+++ b/js8_get_msgs/requirements.txt
@@ -1,0 +1,1 @@
+mysql-connector-python==9.1.0

--- a/js8_web/requirements.txt
+++ b/js8_web/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+mysql-connector-python==9.1.0


### PR DESCRIPTION
Fixes #11

Add requirements.txt files to the js8_get_msgs and js8_web directories.

* Add `mysql-connector-python==9.1.0` to `js8_get_msgs/requirements.txt`.
* Add `Flask` and `mysql-connector-python==9.1.0` to `js8_web/requirements.txt`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jaqvil/js8_message_grid/pull/12?shareId=28d9d198-0344-480c-b472-66a16fafbd35).